### PR TITLE
Add support for passing options to GSS

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -137,6 +137,9 @@ let BuildConfig = function(config) {
     compilation_level: 'SIMPLE_OPTIMIZATIONS',
   };
 
+  /** @type {!object} */
+  this.closureStylesheetsCompilerOptions = this.options.gss || {};
+
   /** @type {!string} */
   this.soyPath = (this.out) ? this.out : path.join(this.tempPath, 'soy');
 


### PR DESCRIPTION
This pull request adds a simple change that allows passing options to the GSS compiler, through a build config property called `gss`, to match `soy` and `closure`.